### PR TITLE
Use more convenient way to checkout the project sources.

### DIFF
--- a/pipelines/stub/Jenkinsfile
+++ b/pipelines/stub/Jenkinsfile
@@ -1,0 +1,37 @@
+// The shared library declaration is required here. Otherwise
+// loading of the central pipeline script fails.
+@Library('piper-library-os') _
+
+node {
+
+    // temporary folder used for storing the central jenkins file locally.
+    def TMP_PIPELINE_FOLDER = "pipeline-${UUID.randomUUID().toString()}"
+
+    // The coordinates of the central pipeline script
+    def REPO = 'https://github.com/SAP/jenkins-pipelines.git'
+    def BRANCH = 'master'
+    def PATH = 'pipelines/ui5-sap-cp/Jenkinsfile'
+
+    // In case access to the repository containing the central pipeline
+    // script is restricted the credentialsId of the credentials used for
+    // accessing the repository needs to be provided below. The corresponding
+    // credentials needs to be configured in Jenkins accordingly.
+    def CREDENTIALS_ID = ''
+
+    deleteDir()
+    dir(TMP_PIPELINE_FOLDER) {
+
+        checkout([$class: 'GitSCM', branches: [[name: BRANCH]], 
+                                    doGenerateSubmoduleConfigurations: false, 
+                                    extensions: [[$class: 'SparseCheckoutPaths', 
+                                                  sparseCheckoutPaths: [[path: PATH]]
+                                                ]], 
+                                                submoduleCfg: [], 
+                                                userRemoteConfigs: [[credentialsId: CREDENTIALS_ID, 
+                                                                     url: REPO
+                                                                    ]]
+                  ])
+    }
+    
+    load "${TMP_PIPELINE_FOLDER}/${PATH}"
+}

--- a/pipelines/ui5-sap-cp/Jenkinsfile
+++ b/pipelines/ui5-sap-cp/Jenkinsfile
@@ -21,9 +21,8 @@ node() {
 
   stage("Clone sources and setup environment"){
     deleteDir()
-    def gitCoordinates = new Utils().retrieveGitCoordinates(this)
-    checkout([$class: 'GitSCM', branches: [[name: gitCoordinates.branch]], doGenerateSubmoduleConfigurations: false, extensions: [[$class: 'RelativeTargetDirectory', relativeTargetDir: APP_PATH]], submoduleCfg: [], userRemoteConfigs: [[url: gitCoordinates.url]]])
     dir(APP_PATH) {
+      checkout scm
       setupCommonPipelineEnvironment script: this, configFile: CONFIG_FILE
     }
     MTA_JAR_LOCATION = commonPipelineEnvironment.getConfigProperty('MTA_HOME')
@@ -69,5 +68,3 @@ node() {
     }
   }
 }
-
-


### PR DESCRIPTION
With that approach the project sources are checked out using
projectUrl, branch and credentials from the job configuration.

In case of using this pipeline script as a central pipeline
script, not contained in the project sources, but served from a
central repo, the projectUrl and the branch of the "payload"
repo needed to be provided via job parameters. This way is
now not supported anymore.

Instead the "payload" repo needs to be referenced always directly in
the job configuration. Hence there is no need anymore for having
repository URL and branch as job parameters. The central pipeline
script is now expected to be loaded from a stub pipeline script
located in the "payload" repo. An example for such a stub pipeline
script is contained in this commit (pipelines/stub/Jenkinsfile).

Advantage of that approach: In case the "payload" repo is protected
with credentials we can use directly use the credentialsId which is
provided in the job configuration together with repoUrl and branch.
Before this was not possible since the repoUrl, the branch and the
credentialsId configured in the job was thatone of the central
pipeline script rather than thatpone of the "payload" repo.

Disadvantate of that approach: The central pipeline script can be
disabled by project members by not using the stub file or by changing
this file.