### PR TITLE
Remove mtar file handing from pipeline

### DIFF
--- a/pipelines/ui5-sap-cp/Jenkinsfile
+++ b/pipelines/ui5-sap-cp/Jenkinsfile
@@ -59,7 +59,7 @@ node() {
   stage("Build Fiori App"){
     dir(SRC){
       withEnv(["http_proxy=${proxy}", "https_proxy=${httpsProxy}"]) {
-        MTAR_FILE_PATH = mtaBuild script: this, mtaJarLocation: MTA_JAR_LOCATION, buildTarget: 'NEO'
+        mtaBuild script: this, mtaJarLocation: MTA_JAR_LOCATION, buildTarget: 'NEO'
       }
     }
   }
@@ -67,7 +67,7 @@ node() {
   stage("Deploy Fiori App"){
     dir(SRC){
       withEnv(["http_proxy=${proxy}", "https_proxy=${httpsProxy}"]) {
-        neoDeploy script: this, neoHome: NEO_HOME, archivePath: MTAR_FILE_PATH
+        neoDeploy script: this, neoHome: NEO_HOME
       }
     }
   }


### PR DESCRIPTION
Since commit 50ac5b0ac96af15261abc4f03d55cbdd77221c7e inside piper-lib-os there is
no return value anymore for mtaBuild. In the meantime we have the policy of not
returning return values from steps. This is not possible anyway for declarative
pipelines. Would be possible for scripted pipelines, but should not be supported
for the sake of handling things in the same way.
Since this commit MTAR_FILE_PATH is always null. Since we set that file path
in the common pipeline environment and since this paramater is taken into account
inside neoDeploy this pipeline here works nevertheless.

Customers using this pipeline in the past as template and relying on the
mtar file path for some other tasks will fail when using a newer version of
the shared lib, but this is another story.

Customers starting with the new version of the template will not get the idea
of doing it this way. The mtar file path is still available via common
pipeline environment.